### PR TITLE
Update Qodana linter version to 2025.1

### DIFF
--- a/qodana.yml
+++ b/qodana.yml
@@ -2,7 +2,7 @@
 # https://www.jetbrains.com/help/qodana/qodana-yaml.html
 
 version: 1.0
-linter: jetbrains/qodana-jvm-community:2024.2
+linter: jetbrains/qodana-jvm-community:2025.1
 projectJDK: "17"
 profile:
   name: qodana.recommended


### PR DESCRIPTION
Upgraded the linter from version 2024.2 to 2025.1 in qodana.yml. This ensures compatibility with the latest features and improvements provided by the new version. No other changes were made.