### PR TITLE
Add color settings for CSS and HTML tag elements

### DIFF
--- a/src/main/resources/Everforest_Dark_Hard.xml
+++ b/src/main/resources/Everforest_Dark_Hard.xml
@@ -405,6 +405,11 @@
         <option name="FOREGROUND" value="dbbc7f" />
       </value>
     </option>
+    <option name="CSS.CLASS_NAME">
+      <value>
+        <option name="FOREGROUND" value="e67e80" />
+      </value>
+    </option>
     <option name="CSS.COLOR">
       <value>
         <option name="FOREGROUND" value="7fbbb3" />
@@ -761,7 +766,11 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HTML_TAG_NAME" baseAttributes="DEFAULT_KEYWORD" />
+    <option name="HTML_TAG_NAME">
+      <value>
+        <option name="FOREGROUND" value="e69875" />
+      </value>
+    </option>
     <option name="IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="404c51" />

--- a/src/main/resources/Everforest_Dark_Medium.xml
+++ b/src/main/resources/Everforest_Dark_Medium.xml
@@ -405,6 +405,11 @@
                 <option name="FOREGROUND" value="dbbc7f" />
             </value>
         </option>
+        <option name="CSS.CLASS_NAME">
+            <value>
+                <option name="FOREGROUND" value="e67e80" />
+            </value>
+        </option>
         <option name="CSS.COLOR">
             <value>
                 <option name="FOREGROUND" value="7fbbb3" />
@@ -740,7 +745,11 @@
         <option name="HTML_ATTRIBUTE_VALUE" baseAttributes="DEFAULT_STRING" />
         <option name="HTML_CUSTOM_TAG_NAME" baseAttributes="HTML_TAG_NAME" />
         <option name="HTML_ENTITY_REFERENCE" baseAttributes="DEFAULT_ENTITY" />
-        <option name="HTML_TAG_NAME" baseAttributes="DEFAULT_KEYWORD" />
+        <option name="HTML_TAG_NAME">
+            <value>
+                <option name="FOREGROUND" value="e69875" />
+            </value>
+        </option>
         <option name="IDENTIFIER_UNDER_CARET_ATTRIBUTES">
             <value>
                 <option name="BACKGROUND" value="404c51" />

--- a/src/main/resources/Everforest_Dark_Soft.xml
+++ b/src/main/resources/Everforest_Dark_Soft.xml
@@ -410,6 +410,11 @@
                 <option name="FOREGROUND" value="7fbbb3" />
             </value>
         </option>
+        <option name="CSS.CLASS_NAME">
+            <value>
+                <option name="FOREGROUND" value="e67e80" />
+            </value>
+        </option>
         <option name="CSS.IMPORTANT" baseAttributes="DEFAULT_KEYWORD" />
         <option name="CSS.URL" baseAttributes="HTML_ATTRIBUTE_VALUE" />
         <option name="CTRL_CLICKABLE">
@@ -754,7 +759,11 @@
         <option name="HTML_ATTRIBUTE_VALUE" baseAttributes="DEFAULT_STRING" />
         <option name="HTML_CUSTOM_TAG_NAME" baseAttributes="HTML_TAG_NAME" />
         <option name="HTML_ENTITY_REFERENCE" baseAttributes="DEFAULT_ENTITY" />
-        <option name="HTML_TAG_NAME" baseAttributes="DEFAULT_KEYWORD" />
+        <option name="HTML_TAG_NAME">
+            <value>
+                <option name="FOREGROUND" value="e69875" />
+            </value>
+        </option>
         <option name="HYPERLINK_ATTRIBUTES">
             <value>
                 <option name="FOREGROUND" value="287bde" />

--- a/src/main/resources/Everforest_Light_Hard.xml
+++ b/src/main/resources/Everforest_Light_Hard.xml
@@ -505,6 +505,16 @@
                 <option name="EFFECT_TYPE" value="1" />
             </value>
         </option>
+        <option name="CSS.CLASS_NAME">
+            <value>
+                <option name="FOREGROUND" value="f85552" />
+            </value>
+        </option>
+        <option name="HTML_TAG_NAME">
+            <value>
+                <option name="FOREGROUND" value="f57d26" />
+            </value>
+        </option>
         <option name="IDENTIFIER_UNDER_CARET_ATTRIBUTES">
             <value>
                 <option name="BACKGROUND" value="edead5" />

--- a/src/main/resources/Everforest_Light_Medium.xml
+++ b/src/main/resources/Everforest_Light_Medium.xml
@@ -505,6 +505,16 @@
                 <option name="EFFECT_TYPE" value="1" />
             </value>
         </option>
+        <option name="CSS.CLASS_NAME">
+            <value>
+                <option name="FOREGROUND" value="f85552" />
+            </value>
+        </option>
+        <option name="HTML_TAG_NAME">
+            <value>
+                <option name="FOREGROUND" value="f57d26" />
+            </value>
+        </option>
         <option name="IDENTIFIER_UNDER_CARET_ATTRIBUTES">
             <value>
                 <option name="BACKGROUND" value="edead5" />

--- a/src/main/resources/Everforest_Light_Soft.xml
+++ b/src/main/resources/Everforest_Light_Soft.xml
@@ -120,6 +120,11 @@
                 <option name="FOREGROUND" value="8da101" />
             </value>
         </option>
+        <option name="CSS.CLASS_NAME">
+            <value>
+                <option name="FOREGROUND" value="f85552" />
+            </value>
+        </option>
         <option name="BASH.HERE_DOC">
             <value>
                 <option name="FOREGROUND" value="35a77c" />
@@ -503,6 +508,11 @@
                 <option name="FOREGROUND" value="287bde" />
                 <option name="EFFECT_COLOR" value="287bde" />
                 <option name="EFFECT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="HTML_TAG_NAME">
+            <value>
+                <option name="FOREGROUND" value="f57d26"/>
             </value>
         </option>
         <option name="IDENTIFIER_UNDER_CARET_ATTRIBUTES">


### PR DESCRIPTION
This commit introduces foreground colors for `CSS.CLASS_NAME` and `HTML_TAG_NAME` across all Everforest theme variants. It ensures a more consistent and visually distinct representation of these elements within the themes.